### PR TITLE
Fix errors found during additional testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-build: python-packages links
+build: python-packages links env/bin/srcml
 
 .PHONY: links
 links: env/bin/apply.py
@@ -6,12 +6,17 @@ links: env/bin/apply.py
 env/bin/apply.py: env
 	ln -s $$(realpath scripts/patch_apply/apply.py) env/bin
 
+env/bin/srcml:
+	if [ -z "$$(which srcml)" ]; then cd env; curl http://gehry.sdml.cs.kent.edu/lmcrs/v1.0.0/srcml_1.0.0-1_ubuntu20.04.tar.gz | tar -zxv ; else ln -s "$$(which srcml)" /env/bin/srcml; fi
+	if [ -f "env/bin/srcml" ]; then mv env/bin/srcml env/bin/srcml-binary; echo '#!/bin/bash\nLD_LIBRARY_PATH=$(CURDIR)/env/lib exec srcml-binary $$*' >env/bin/srcml; chmod +x env/bin/srcml; fi;
+
 .PHONY: python-packages
 python-packages: env
 	@if [ ! -d env/lib/python*/site-packages/diff_match_patch ]; then echo "Installing diff_match_patch"; . env/bin/activate; python3 -m pip install diff_match_patch; fi
 	@if [ ! -d env/lib/python*/site-packages/Levenshtein ]; then echo "Installing Levenshtein"; . env/bin/activate; python3 -m pip install Levenshtein; fi
 	@if [ ! -d env/lib/python*/site-packages/pygments ]; then echo "Installing diff_match_patch"; . env/bin/activate; python3 -m pip install pygments; fi
 	@if [ ! -x env/bin/pytest ]; then echo "Installing pytest"; . env/bin/activate; python3 -m pip install pytest; fi
+	@if [ ! -x env/bin/pytest-cov ]; then echo "Installing pytest-cov"; . env/bin/activate; python3 -m pip install pytest-cov; fi
 
 env:
 	python3 -m venv env

--- a/scripts/patch_apply/check_file_exists_elsewhere.py
+++ b/scripts/patch_apply/check_file_exists_elsewhere.py
@@ -30,8 +30,8 @@ def checkFileExistsElsewhere(patch):
 
     if len(matched_file_locations) == 0:
         return None
-    else:
-        print("----------------------------------------------------------------------")
+    elif sys.stdout.isatty():
+        print("-" * 70)
         print(
             "Here are the locations of files with the same filename as the following missing file: {}".format(
                 toFind
@@ -44,7 +44,7 @@ def checkFileExistsElsewhere(patch):
             "Select the file you would like to apply the patch to by entering the number next to it. Enter anything else to do nothing\n"
         )
 
-        print("----------------------------------------------------------------------")
+        print("-" * 70)
         try:
             to_apply_file_index = int(to_apply_file_index)
             if 0 <= to_apply_file_index and to_apply_file_index < len(
@@ -53,7 +53,10 @@ def checkFileExistsElsewhere(patch):
                 return matched_file_locations[to_apply_file_index]
         except ValueError:
             return None
-
+    else:
+        print(f"Possible files to apply the patch for {toFind} to:")
+        for i in matched_file_locations:
+            print(f"  {i}")
 
 # Testing
 # patch_file = parse.PatchFile("../vulnerableforks/patches/CVE-2014-8172.patch")

--- a/scripts/patch_context/context_changes.py
+++ b/scripts/patch_context/context_changes.py
@@ -41,12 +41,20 @@ def context_changes(sub_patch, expand=False):
     file_path = os.path.join( os.getcwd(), sub_patch.getFileName() )
 
     if not os.path.exists(file_path):
-        return ContextResult(
-            CONTEXT_DECISION.DONT_RUN.value,
-            "The file %s does not exist" % (file_path),
-            None,
-            False,
-        )
+        if not sub_patch.isNewFile():
+            return ContextResult(
+                CONTEXT_DECISION.DONT_RUN.value,
+                "The file %s does not exist" % (file_path),
+                None,
+                False,
+            )
+        else:
+            return ContextResult(
+                CONTEXT_DECISION.RUN.value,
+                "No context related issues found.",
+                None,
+                False,
+            )
 
     file_slice = slice.SliceParser(file_path)
     file_slice_parsed = file_slice.slice_parse()

--- a/scripts/patch_context/slice_and_parse.py
+++ b/scripts/patch_context/slice_and_parse.py
@@ -1,4 +1,4 @@
-import os, subprocess, sys
+import os, subprocess, threading, sys
 import tempfile as tfile
 import re
 from enum import Enum
@@ -9,35 +9,61 @@ if sys.platform.startswith("darwin"):
 else:
     src_slice_path += "/srcSliceBuilds/ubuntu/srcslice-ubuntu"
 
+class RunWithTimeout(object):
+    def __init__(self, cmd):
+        self.cmd = cmd
+        self.process = None
+        self.out = None
+        self.err = None
+
+    def run(self, timeout):
+        def target():
+            self.process = subprocess.Popen( args=self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE )
+            self.out, self.err = self.process.communicate()
+
+        thread = threading.Thread(target=target)
+        thread.start()
+
+        for i in range(0, timeout, 5):
+            thread.join(5)
+            if not thread.is_alive():
+                break
+
+            print( f"Waited {i} seconds for {self.cmd} to exit." )
+
+        if thread.is_alive():
+            print( f"Timeout waiting for {self.cmd} to exit." )
+            self.process.terminate()
+            thread.join()
+            self.err += f"Timeout waiting for {self.cmd} to exit.".encode('ascii')
+
 class SliceParser:
     def __init__(self, file):
         self.file = file
 
     def slice_parse(self):
-        p = subprocess.Popen(
-            ["srcml", f"{self.file}", "--position"], stdout=subprocess.PIPE
-        )
-        out, err = p.communicate()
 
-        if err:
+        srcml = RunWithTimeout(["srcml", f"{self.file}", "--position"])
+        srcml.run(timeout=120)
+
+        if srcml.err:
             return None
 
         fd, path = tfile.mkstemp(suffix=".xml", prefix="temp")
         try:
             with os.fdopen(fd, "w") as tmpo:
-                tmpo.write(str(out, "utf-8"))
+                tmpo.write(str(srcml.out, "utf-8"))
 
-            p = subprocess.Popen(
-                [
-                    src_slice_path,
-                    f"{path}",
-                ],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            out, err = p.communicate()
+            srcslice = RunWithTimeout([src_slice_path, f"{path}"])
+            srcslice.run(timeout=120)
 
-            str_out = out.decode("utf-8")
+            # Remove the "Time is: ...." line from the error output.
+            srcslice.err = re.sub(b'Time is: [0-9.]*\n', b'', srcslice.err)
+
+            if srcslice.err:
+                return None
+
+            str_out = srcslice.out.decode("utf-8")
             slice_dict = {}
             for line in str_out.splitlines():
 

--- a/scripts/patch_match/test_match.py
+++ b/scripts/patch_match/test_match.py
@@ -357,7 +357,7 @@ def compare_nearby(patch_idx, patch_lines, file_idx, file_lines):
 def find_diffs(patch_obj, file_name, retry_obj=None, match_distance=3000):
     dmp.Match_Distance = match_distance
     function_for_patch, patch_lines = patch_obj._lines[0][1], patch_obj._lines[1:]
-    line_number = patch_obj._lineschanged[2]
+    line_number = patch_obj._newStart
 
     search_lines_with_type = get_file_without_patch(patch_lines)
     search_lines_without_type = [line[1] for line in search_lines_with_type]

--- a/tests/patches/applied/add-pluses.patch
+++ b/tests/patches/applied/add-pluses.patch
@@ -1,0 +1,12 @@
+--- a/patches/pluses.c	2022-07-08 12:10:09.838919861 -0400
++++ b/patches/pluses.c	2022-07-08 12:08:21.758457580 -0400
+@@ -1,5 +1,9 @@
+ #include <stdio.h>
+ 
++/*
++++ This is a line with two plus signs at the front.
++*/
++
+ int main( int argc, char ** argv ) {
+     printf( "Hello world.\n" );
+ }

--- a/tests/patches/applied/remove-negatives.patch
+++ b/tests/patches/applied/remove-negatives.patch
@@ -1,0 +1,13 @@
+--- a/patches/pluses.c	2022-07-08 12:10:51.635102787 -0400
++++ b/patches/pluses.c	2022-07-08 12:08:21.758457580 -0400
+@@ -1,10 +1,6 @@
+ #include <stdio.h>
+ 
+ /*
+--- This is a line with two negative signs at the front.
+-*/
+-
+-/*
+ ++ This is a line with two plus signs at the front.
+ */
+ 

--- a/tests/patches/clean/add-file.patch
+++ b/tests/patches/clean/add-file.patch
@@ -1,0 +1,65 @@
+--- /dev/null	2022-07-07 08:45:46.573671159 -0400
++++ patches/switch-new.cpp	2022-04-22 13:51:48.544311829 -0400
+@@ -0,0 +1,62 @@
++#include <stdio.h>
++#include <stdlib.h>
++
++enum option_t {
++    OPT_ONE,
++    OPT_TWO,
++    OPT_THREE,
++    OPT_FOUR,
++    OPT_FIVE,
++    OPT_SIX,
++};
++
++int print_switch( option_t option ) {
++
++    if( option > 6 ) {
++        printf( "Bad index %d.", option );
++        return -1;
++    }
++    
++    switch( option ) {
++
++    case OPT_ONE:
++        printf( "Found option 1.\n" );
++        break;
++
++    case OPT_TWO:
++        printf( "Found option 2.\n" );
++        break;
++
++    case OPT_THREE:
++        printf( "Found option 3.\n" );
++        break;
++
++    case OPT_FOUR:
++        printf( "Found option 4.\n" );
++        break;
++
++    case OPT_FIVE:
++        printf( "Found option 5.\n" );
++        break;
++
++    case OPT_SIX:
++        printf( "Found option 6.\n" );
++        break;
++
++    default:
++        printf( "Unknown option: %d\n", option );
++        break;
++    }
++    return 0;
++}
++
++int main( int argc, char ** argv ) {
++    if( argc < 2 ) {
++        fprintf( stderr, "Missing argument.\n" );
++        return 1;
++    }
++
++    option_t option = (option_t)atoi( argv[1] );
++    print_switch( option );
++    return 0;
++}

--- a/tests/patches/clean/add-pluses.patch
+++ b/tests/patches/clean/add-pluses.patch
@@ -1,0 +1,13 @@
+--- a/patches/test.cpp	2022-04-22 13:51:48.544311829 -0400
++++ b/patches/test.cpp	2022-07-07 17:53:47.927302814 -0400
+@@ -1,6 +1,10 @@
+ #include <string>
+ #include <memory.h>
+ 
++/*
++++ This is a line with two plus signs at the beginning.
++*/
++
+ typedef struct element_t {
+     size_t length;
+     size_t max_length;

--- a/tests/patches/clean/one-line-after-hunk.patch
+++ b/tests/patches/clean/one-line-after-hunk.patch
@@ -1,0 +1,51 @@
+--- a/patches/test.cpp	2021-04-16 14:10:28.767487311 -0400
++++ b/patches/test.cpp	2021-09-07 10:52:01.472170449 -0400
+@@ -1,48 +1 @@
+ #include <string>
+-#include <memory.h>
+-
+-typedef struct element_t {
+-    size_t length;
+-    size_t max_length;
+-    char buffer[80];
+-} element_t;
+-
+-void copy_to_string( element_t &dst, const char * src ) {
+-    dst.length = strncpy( dst.buffer, src, dst.max_length );
+-    if( dst.length >= dst.max_length )
+-        dst.length = dst.max_length - 1;
+-    dst.buffer[dst.length] = '\0';
+-    return;
+-}
+-
+-std::string MakeString( const char * str ) {
+-    char localString[256];
+-    memset( localString, 0, 256 );
+-    snprintf( localString, 256, "%s", str );
+-
+-    printf( "Location of the string: %p\n", localString );
+-
+-    return localString;
+-}
+-
+-int main( int argc, char ** argv ) {
+-    if( argc < 1 ) {
+-        printf( "This isn't going to work.  I need an argument!\n" );
+-        return 1;
+-    }
+-
+-    std::string value = MakeString( argv[1] );
+-
+-    printf( "String: %s\n", value.c_str() );
+-    printf( "Location of the string: %p\n", value.c_str() );
+-
+-    // Now, copy it into another buffer.
+-    element_t element;
+-    element.max_length = sizeof(element.buffer);
+-
+-    copy_to_string( element, value.c_str() );
+-
+-    printf( "String: %s\n", element.buffer );
+-
+-    return 0;
+-}

--- a/tests/patches/clean/one-line-hunk.patch
+++ b/tests/patches/clean/one-line-hunk.patch
@@ -1,0 +1,6 @@
+--- a/patches/one-line.cpp	2021-09-07 10:46:59.703099221 -0400
++++ b/patches/one-line.cpp	2021-09-07 10:48:11.279353303 -0400
+@@ -1,1 +1,3 @@
++#ifndef ONE_LINE
+ void main(int argc, char **argv) { return 0; }
++#endif /* ONE_LINE */

--- a/tests/patches/clean/remove-file.patch
+++ b/tests/patches/clean/remove-file.patch
@@ -1,0 +1,65 @@
+--- patches/switch.cpp	2022-04-22 13:51:48.544311829 -0400
++++ /dev/null	2022-07-07 08:45:46.573671159 -0400
+@@ -1,62 +0,0 @@
+-#include <stdio.h>
+-#include <stdlib.h>
+-
+-enum option_t {
+-    OPT_ONE,
+-    OPT_TWO,
+-    OPT_THREE,
+-    OPT_FOUR,
+-    OPT_FIVE,
+-    OPT_SIX,
+-};
+-
+-int print_switch( option_t option ) {
+-
+-    if( option > 6 ) {
+-        printf( "Bad index %d.", option );
+-        return -1;
+-    }
+-    
+-    switch( option ) {
+-
+-    case OPT_ONE:
+-        printf( "Found option 1.\n" );
+-        break;
+-
+-    case OPT_TWO:
+-        printf( "Found option 2.\n" );
+-        break;
+-
+-    case OPT_THREE:
+-        printf( "Found option 3.\n" );
+-        break;
+-
+-    case OPT_FOUR:
+-        printf( "Found option 4.\n" );
+-        break;
+-
+-    case OPT_FIVE:
+-        printf( "Found option 5.\n" );
+-        break;
+-
+-    case OPT_SIX:
+-        printf( "Found option 6.\n" );
+-        break;
+-
+-    default:
+-        printf( "Unknown option: %d\n", option );
+-        break;
+-    }
+-    return 0;
+-}
+-
+-int main( int argc, char ** argv ) {
+-    if( argc < 2 ) {
+-        fprintf( stderr, "Missing argument.\n" );
+-        return 1;
+-    }
+-
+-    option_t option = (option_t)atoi( argv[1] );
+-    print_switch( option );
+-    return 0;
+-}

--- a/tests/patches/clean/remove-negatives.patch
+++ b/tests/patches/clean/remove-negatives.patch
@@ -1,0 +1,12 @@
+--- a/patches/negatives.c	2022-07-07 17:55:34.667754758 -0400
++++ b/patches/negatives.c	2022-07-07 17:56:47.488063079 -0400
+@@ -1,9 +1,5 @@
+ #include <stdio.h>
+ 
+-/*
+--- This is a line with two negatives at the front.
+-*/
+-
+ int main( int argc, char ** argv ) {
+     printf( "Hello world.\n" );
+ }

--- a/tests/patches/git/binary-2.patch
+++ b/tests/patches/git/binary-2.patch
@@ -1,0 +1,4 @@
+diff --git a/tests/patches/test.so b/tests/patches/test.so
+new file mode 100644
+index 0000000..649223da
+Binary files /dev/null and b/tests/patches/test.so differ

--- a/tests/patches/git/binary.patch
+++ b/tests/patches/git/binary.patch
@@ -1,0 +1,7 @@
+diff --git a/patches/test.so b/patches/test.so
+new file mode 100644
+index 0..8
+GIT binary patch
+literal 0
+HcmV?d00001
+

--- a/tests/patches/negatives.c
+++ b/tests/patches/negatives.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+/*
+-- This is a line with two negatives at the front.
+*/
+
+int main( int argc, char ** argv ) {
+    printf( "Hello world.\n" );
+}

--- a/tests/patches/one-line.cpp
+++ b/tests/patches/one-line.cpp
@@ -1,0 +1,1 @@
+void main(int argc, char **argv) { return 0; }

--- a/tests/patches/pluses.c
+++ b/tests/patches/pluses.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+/*
+++ This is a line with two plus signs at the front.
+*/
+
+int main( int argc, char ** argv ) {
+    printf( "Hello world.\n" );
+}

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -66,7 +66,7 @@ class TestApplied(unittest.TestCase):
 
             self.assertRegex( fakeOutput.getvalue(), 'Patch failed to apply with git apply' )
             self.assertRegex( fakeOutput.getvalue(), '1 subpatches can be applied successfully:' )
-            self.assertRegex( fakeOutput.getvalue(), 'would have been successfully applied \(dry run\)' )
+            self.assertRegex( fakeOutput.getvalue(), r'would have been successfully applied \(dry run\)' )
 
     def test_context_function(self):
         with patch('sys.stdout', new=StringIO()) as fakeOutput:
@@ -78,7 +78,7 @@ class TestApplied(unittest.TestCase):
 
             self.assertRegex( fakeOutput.getvalue(), 'Patch failed to apply with git apply' )
             self.assertRegex( fakeOutput.getvalue(), '1 subpatches can be applied successfully:' )
-            self.assertRegex( fakeOutput.getvalue(), 'would have been successfully applied \(dry run\)' )
+            self.assertRegex( fakeOutput.getvalue(), r'would have been successfully applied \(dry run\)' )
 
     def test_applied_offset(self):
         with patch('sys.stdout', new=StringIO()) as fakeOutput:
@@ -112,6 +112,26 @@ class TestApplied(unittest.TestCase):
             self.assertNotRegex( fakeOutput.getvalue(), 'Subpatches that were applied by git apply:' )
             self.assertRegex( fakeOutput.getvalue(), 'Subpatches that did not apply, and we could not find where the patch should be applied' )
 
+    def test_binary(self):
+        with patch('sys.stdout', new=StringIO()) as fakeOutput:
+            apply.main( pathToPatch='patches/git/binary.patch',
+                        dry_run=True,
+                        reverse=False,
+                        verbose=2,
+            )
+
+            self.assertRegex( fakeOutput.getvalue(), ':skipped' )
+
+    def test_binary2(self):
+        with patch('sys.stdout', new=StringIO()) as fakeOutput:
+            apply.main( pathToPatch='patches/git/binary-2.patch',
+                        dry_run=True,
+                        reverse=False,
+                        verbose=2,
+            )
+
+            self.assertRegex( fakeOutput.getvalue(), 'cannot apply binary patch to ' )
+            self.assertRegex( fakeOutput.getvalue(), r'Binary patch detected\.' )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -78,7 +78,7 @@ class TestChanges(unittest.TestCase, metaclass=PatchTests):
             'canApply': precheckStatus.NO_MATCH_FOUND
         },
         'test_code_missing': {
-            'message': r'^No context related issues found\.$',
+            'message': r'^A context match was not found\.$',
             'canApply': precheckStatus.CAN_APPLY
         },
     }

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -90,11 +90,11 @@ class TestContext(unittest.TestCase, metaclass=ContextPatchTests):
             'canApply': precheckStatus.NO_MATCH_FOUND
         },
         'test_variable_change': {
-            'message': r'^This patch can be applied\.$',
+            'message': r'recommend to not run this patch',
             'canApply': precheckStatus.NO_MATCH_FOUND
         },
         'test_variable_change_declaration': {
-            'message': r'^This patch can be applied\.$',
+            'message': r'recommend to not run this patch',
             'canApply': precheckStatus.NO_MATCH_FOUND
         },
         'test_variable_change_LHS': {

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -72,6 +72,14 @@ class TestPatches(unittest.TestCase, metaclass=PatchTests):
         'test_bad_index': {
             'result': 'skipped',
             'success': False
+        },
+        'test_binary': {
+            'result': 'skipped',
+            'success': False
+        },
+        'test_binary_2': {
+            'result': 'patch does not apply',
+            'success': False
         }
     }
 


### PR DESCRIPTION
This patch fixes a number of errors encountered during internal testing:

1. Processing of hunks within a patch file was incorrect.  We were starting a new hunk every time we saw a --- or +++, but we should have been looking at the number of lines remaining in the current hunk (which started with a @@) to determine if we were at the end of the hunk.  In the rare case where the patch is removing a line that starts with --, or adding a line that starts with ++, you'll have a --- or +++ within the hunk which we were treating as a new hunk even though it should not have been.  Now, instead of looking for a +++ or --- on every line, we count the number of lines which should be in the hunk and treat those lines as part of the hunk instead of starting a new hunk.  As part of implementing this feature, we renamed the _lineschanged array to the more descriptive _oldStart, _oldLength, _newStart, and _newLength variables.

2. We were not handling hunks which created or removed files correctly.  In this case, either the source or target file will appear as /dev/null and we should be able to handle this.

3. On occasion, srcml was hanging which meant that apply.py also hung. Implement a timeout on the external program calls so that we can detect hangs and error out.

4. We do not handle binary patches, but we should be able to detect when they appear and raise an appropriate error.

5. Update the Makefile to automatically install srcml if it's not already installed.  The http://gehry.sdml.cs.kent.edu site is unfortunately not available over HTTPS (it's a self-signed certificate and a default Apache testing page) and so for now we are downloading over HTTP.  We install it into the env path.

6. Only ask questions about the possible files to apply the patch to if we are running over a TTY.  This avoids the questions being asked if the output of apply.py is being piped to a file or another program.

Unit tests are added for 1, 2, and 4 above.